### PR TITLE
fix: passing complete buf size argument to _jsonb_escape

### DIFF
--- a/json-build.h
+++ b/json-build.h
@@ -400,7 +400,7 @@ jsonb_key(jsonb *b, char buf[], size_t bufsize, const char key[], size_t len)
     case JSONB_OBJECT_KEY_OR_CLOSE: {
         enum jsonbcode ret;
         BUFFER_COPY_CHAR(b, '"', pos, buf, bufsize);
-        ret = _jsonb_escape(&pos, buf + b->pos, bufsize, key, len);
+        ret = _jsonb_escape(&pos, buf + b->pos, bufsize - b->pos, key, len);
         if (ret != JSONB_OK) return ret;
         BUFFER_COPY(b, "\":", 2, pos, buf, bufsize);
         STACK_HEAD(b, JSONB_OBJECT_VALUE);
@@ -551,7 +551,7 @@ jsonb_string(
         return JSONB_ERROR_INPUT;
     }
     BUFFER_COPY_CHAR(b, '"', pos, buf, bufsize);
-    ret = _jsonb_escape(&pos, buf + b->pos, bufsize, str, len);
+    ret = _jsonb_escape(&pos, buf + b->pos, bufsize - b->pos, str, len);
     if (ret != JSONB_OK) return ret;
     BUFFER_COPY_CHAR(b, '"', pos, buf, bufsize);
     STACK_HEAD(b, next_state);


### PR DESCRIPTION
Complete buf size is passed to _jsonb_escape even if buf is passed on b->pos. This might result in a memory leak as _jsonb_escape might write beyond buf limits